### PR TITLE
refact: [Main code] Usercommand Enum으로 분리

### DIFF
--- a/src/main/java/shell/Controller.java
+++ b/src/main/java/shell/Controller.java
@@ -14,20 +14,25 @@ public class Controller {
     }
 
     public void sendService(UserInput userInput) {
-        if (userInput.getCommend().equals("read")) {
-            service.read(userInput.getLBA());
-        }
-        else if (userInput.getCommend().equals("write")) {
-            service.write(userInput.getLBA(), userInput.getValue());
-        }
-        else if (userInput.getCommend().equals("help")) {
-            service.help();
-        }
-        else if (userInput.getCommend().equals("fullwrite")) {
-            service.fullwrite(userInput.getValue());
-        }
-        else if (userInput.getCommend().equals("fullread")) {
-            service.fullread();
+        UserCommand command = UserCommand.fromString(userInput.getCommand());
+        switch (command) {
+            case READ:
+                service.read(userInput.getLBA());
+                break;
+            case WRITE:
+                service.write(userInput.getLBA(), userInput.getValue());
+                break;
+            case HELP:
+                service.help();
+                break;
+            case FULLWRITE:
+                service.fullwrite(userInput.getValue());
+                break;
+            case FULLREAD:
+                service.fullread();
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported command: " + command);
         }
     }
 }

--- a/src/main/java/shell/UserCommand.java
+++ b/src/main/java/shell/UserCommand.java
@@ -1,0 +1,24 @@
+package shell;
+
+public enum UserCommand {
+    READ("read"),
+    WRITE("write"),
+    HELP("help"),
+    FULLWRITE("fullwrite"),
+    FULLREAD("fullread");
+
+    private final String command;
+
+    UserCommand(String command) {
+        this.command = command;
+    }
+
+    public static UserCommand fromString(String command) {
+        for (UserCommand c : UserCommand.values()) {
+            if (c.command.equalsIgnoreCase(command)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException("Unknown command: " + command);
+    }
+}

--- a/src/main/java/shell/dto/UserInput.java
+++ b/src/main/java/shell/dto/UserInput.java
@@ -1,22 +1,22 @@
 package shell.dto;
 
 public class UserInput {
-    String commend;
+    String command;
     int LBA;
     String value;
 
-    public UserInput(String commend, int LBA, String value) {
-        this.commend = commend;
+    public UserInput(String command, int LBA, String value) {
+        this.command = command;
         this.LBA = LBA;
         this.value = value;
     }
 
-    public String getCommend() {
-        return commend;
+    public String getCommand() {
+        return command;
     }
 
-    public void setCommend(String commend) {
-        this.commend = commend;
+    public void setCommand(String command) {
+        this.command = command;
     }
 
     public int getLBA() {


### PR DESCRIPTION
모든 명령 문자열을 Command Enum에 정의하여, 명령어의 검증과 관리를 용이하게 합니다. 
실제 실행 로직은 여전히 Service 클래스 내에 유지되어, 로직과 데이터의 분리 원칙을 따르게 됩니다. 
또한, 새로운 명령어를 추가하려면 Command Enum에만 추가하면 되므로, 유지 보수 및 확장성이 향상됩니다.